### PR TITLE
make bysetpos iterate rather than precompute

### DIFF
--- a/lib/DateTime/Event/ICal.pm
+++ b/lib/DateTime/Event/ICal.pm
@@ -389,7 +389,7 @@ sub _recur_bysetpos {
     # die "invalid bysetpos parameter [@{$args{bysetpos}}]" 
     #     unless @{$args{bysetpos}};
     # print STDERR "bysetpos:  [@{$args{bysetpos}}]\n";
-#   for ( @{$args{bysetpos}} ) { $_-- if $_ > 0 }
+    # for ( @{$args{bysetpos}} ) { $_-- if $_ > 0 }
 
     return DateTime::Set->from_recurrence (
         next =>
@@ -412,7 +412,7 @@ sub _recur_bysetpos {
                     if ( $pos >= 0 ) {
                         my $next = $start->clone;
                         $next->subtract( nanoseconds => 1 );
-                        while ( $pos-- >= 0 ) { 
+                        while ( $pos-- > 0 ) {
                             # print STDERR "    next: $pos ".$next->datetime."\n";
                             $next = $args{recurrence}->next( $next ) 
                         }
@@ -500,7 +500,7 @@ sub _recur_bysetpos {
                     } else { # negative setpos, look from end
                         my $n = $end;
                         while($pc++ < 0) {
-                            my $nn = $it->previous($n);
+                            my $nn = $it->previous;
                             $n = $nn if defined $nn;
                         }
                         return $n if $n < $self;

--- a/t/03by.t
+++ b/t/03by.t
@@ -2,7 +2,7 @@
 
 use strict;
 
-use Test::More tests => 7;
+use Test::More tests => 8;
 
 use DateTime;
 use DateTime::Event::ICal;
@@ -107,7 +107,6 @@ use DateTime::Event::ICal;
         '2004-01-09T10:10:45 2004-01-09T14:10:45',
         "yearly, dtstart, byday=1fr,2fr,-1tu, byhour" );
 
-
     # MONTHLY BYSETPOS
     $set = DateTime::Event::ICal->recur(
        freq =>       'monthly',
@@ -115,7 +114,6 @@ use DateTime::Event::ICal;
        bymonthday => [ -1, -2, -3, -4, -5, -6 ],
        bysetpos =>   [ 3, -2 ],
     );
-
 
     @dt = $set->as_list( start => $dt1,
                          end => $dt1->clone->add( months => 3 ) );
@@ -126,6 +124,23 @@ use DateTime::Event::ICal;
         '2003-05-30T12:10:45 2003-06-27T12:10:45 2003-06-29T12:10:45 '.
         '2003-07-28T12:10:45',
         "monthly, bymonthday, bysetpos" ); 
+
+    # 3-YEARLY BYSETPOS
+    # RRULE:FREQ=YEARLY;INTERVAL=3;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=-1
+    $set = DateTime::Event::ICal->recur(
+       freq =>       'yearly',
+       interval =>   3,
+       dtstart =>    $dt1,
+       byday =>      [ 'mo', 'tu', 'we', 'th', 'fr', 'sa', 'su' ],
+       bysetpos =>   [ -1 ],
+    );
+
+
+    @dt = $set->as_list( start => $dt1,
+                         end => $dt1->clone->add( years => 9 ) );
+    $r = join(' ', map { $_->datetime } @dt);
+    is( $r, '2003-12-31T12:10:45 2006-12-31T12:10:45 2009-12-31T12:10:45',
+        "3-yearly, last day of year, bysetpos" );
 
 
 }


### PR DESCRIPTION
I ran into this RRULE in the wild recently:

    RRULE:FREQ=YEARLY;INTERVAL=3;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=-1

It completely blew up the cpu for longer than I cared to wait for. The as_list call has pathological performance on sparse recurrences, and this PR fixes that by making the `next` and `previous` handlers iterate over the `bysetpos` values.

https://github.com/17hats/DateTime-Set/pull/2 is a prerequisite for this PR. Without it, the `as_list` calls in the tests break...